### PR TITLE
index: populate posts list with h-feed / h-entry microformats

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setuptools.setup(
         'html5lib>=0.9999999,<2.0dev',
         'Jinja2>=2.8,<3.0dev',
         'setuptools>=28.0.0',
+        'python-dateutil>=2.0.0,<3.0dev',
     ],
     entry_points={
         'console_scripts': [

--- a/ssite/index.py
+++ b/ssite/index.py
@@ -30,6 +30,7 @@ from __future__ import print_function
 
 import collections
 import datetime
+import itertools
 import os
 import os.path
 import re
@@ -183,13 +184,18 @@ def extract_summary(site_root, index_root, path, date, markup):
     if summary_elem:
         summary = ''.join(map(str, summary_elem.children))
 
-    # Find only direct children so as not to pick up photos from the h-card.
-    photo_elems = entry.find_all(class_='u-photo', recursive=False)
+    photo_elems_root = entry.find_all(
+        class_='u-photo',
+        # Find only direct children so as not to pick up photos from the
+        # h-card.
+        recursive=False)
+    photo_elems_content = content_elem.find_all(class_='u-photo')
     photos = []
-    for photo_elem in photo_elems:
+    for photo_elem in itertools.chain(photo_elems_root, photo_elems_content):
         photos.append({
+            'id': photo_elem.attrs.get('id'),
             'src': photo_elem['src'],
-            'alt': photo_elem['alt'] if photo_elem.has_attr('alt') else '',
+            'alt': photo_elem.attrs.get('alt', ''),
             'is_pixel_art': 'pixel-art' in photo_elem['class'],
         })
 

--- a/ssite/index.py
+++ b/ssite/index.py
@@ -196,7 +196,7 @@ def extract_summary(site_root, index_root, path, date, markup):
             'id': photo_elem.attrs.get('id'),
             'src': photo_elem['src'],
             'alt': photo_elem.attrs.get('alt', ''),
-            'is_pixel_art': 'pixel-art' in photo_elem['class'],
+            'is_pixel_art': 'u-pixel-art' in photo_elem['class'],
         })
 
     relative_path = os.path.relpath(path, start=index_root)

--- a/tests/index_test.py
+++ b/tests/index_test.py
@@ -23,6 +23,48 @@ import pytest
 import ssite.index
 
 
+@pytest.mark.parametrize('prefix,root,content_path,path,expected', [
+    (
+        'https://example.com/',
+        '/my/site/',
+        '/my/site/blog/entry/',
+        './',
+        'https://example.com/blog/entry/',
+    ),
+    (
+        'https://example.com/',
+        '/my/site/',
+        '/my/site/blog/entry/',
+        '../',
+        'https://example.com/blog/',
+    ),
+    (
+        'https://example.com/',
+        '/my/site/',
+        '/my/site/blog/entry/',
+        '/blog/entry/',
+        'https://example.com/blog/entry/',
+    ),
+    (
+        'https://example.com/',
+        '/my/site/',
+        '/my/site/blog/entry/',
+        'image.png',
+        'https://example.com/blog/entry/image.png',
+    ),
+    (
+        'https://example.com/',
+        '/my/site/',
+        '/my/site/blog/entry/',
+        '/blog/entry/image.png',
+        'https://example.com/blog/entry/image.png',
+    ),
+])
+def test_calculate_absolute_url(prefix, root, content_path, path, expected):
+    got = ssite.index.calculate_absolute_url(prefix, root, content_path, path)
+    assert got == expected
+
+
 def test_flatten_dir():
     test_dir = os.path.dirname(os.path.abspath(__file__))
     filepaths = tuple(sorted(ssite.index.flatten_dir(
@@ -47,8 +89,12 @@ def test_extract_summary_returns_summary():
     assert ssite.index.extract_summary(
             'some/path/index.html',
             datetime.datetime(2016, 5, 5),
-            '<!DOCTYPE html><title>Hello</title>Some beginning text.'
-            ) == ssite.index.Summary(
+            (
+                '<!DOCTYPE html><article class="h-entry">'
+                '<span class="p-name">Hello</span>'
+                '<div class="p-content">Some beginning text.</div>'
+            ),
+            ) == ssite.index.HEntry(
                     'Hello',
                     datetime.datetime(2016, 5, 5),
                     'some/path/',


### PR DESCRIPTION
I've been reworking ssite to read microformats and use that information for the "posts" list when rendering indexes. See: https://github.com/tswast/timswast.com/pull/5 for the changes I made to timswast.com for h-feeds. It allows for more information about the post than just the `<title>` tag, which makes more sense now that I'm adding [untitled notes](https://indieweb.org/note) to my site.

Towards https://github.com/tswast/ssite/issues/4